### PR TITLE
Fix call_method for methods with no argument and add some test.

### DIFF
--- a/pyml_stubs.c
+++ b/pyml_stubs.c
@@ -1008,7 +1008,7 @@ PyObject_CallMethodObjArgs_wrapper(
     mlsize_t argument_count = Wosize_val(arguments_ocaml);
     switch (argument_count) {
     case 0:
-        result = Python_PyObject_CallMethodObjArgs(object, name);
+        result = Python_PyObject_CallMethodObjArgs(object, name, NULL);
         break;
     case 1:
         result = Python_PyObject_CallMethodObjArgs

--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -339,6 +339,28 @@ let () =
       Pyml_tests_common.Passed)
 
 let () =
+  Pyml_tests_common.add_test
+    ~title:"Py.List.sort"
+    (fun () ->
+      let pi_digits = [ 3; 1; 4; 1; 5; 9; 2; 6; 5; 3; 5; 8 ] in
+      let v = Py.List.of_list [] in
+      assert (Py.List.length v = 0);
+      let count = Py.Object.call_method v "count" [|Py.Long.of_int 1|] in
+      assert (Py.Long.to_int count = 0);
+      List.iter
+        (fun i -> ignore (Py.Object.call_method v "append" [|Py.Long.of_int i|]))
+        pi_digits;
+      let count = Py.Object.call_method v "count" [|Py.Long.of_int 1|] in
+      assert (Py.Long.to_int count = 2);
+      assert (Py.List.length v = List.length pi_digits);
+      let _ = Py.Object.call_method v "sort" [||] in
+      let sorted_digits = List.map Py.Int.to_int (Py.List.to_list v) in
+      assert (sorted_digits = List.sort compare pi_digits);
+      let _ = Py.Object.call_method v "clear" [||] in
+      assert (Py.List.length v = 0);
+      Pyml_tests_common.Passed)
+
+let () =
   Pyml_tests_common.add_test ~title:"array"
     (fun () ->
       let array = [| 1; 2 |] in


### PR DESCRIPTION
Hi Thierry,
Thanks for your hard work on pyml.
I came across an issue that causes some segfault/undeterministic behavior when using `Py.Object.call_method` with no argument. I think the problem is that `PyObject_CallMethodObjArgs` should be called with a variable number of parameters followed by NULL and there was no NULL in the 0 argument case.
I also added a test that triggers the issue and works properly after adding the NULL argument.