### PR TITLE
GC issue when registering a function with a dynamically allocated docstring

### DIFF
--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -460,5 +460,26 @@ let () =
     )
 
 let () =
+  Pyml_tests_common.add_test
+    ~title:"docstring"
+    (fun () ->
+      Gc.full_major ();
+      let fn =
+        let docstring = Printf.sprintf "test%d" 42 in
+        Py.Callable.of_function ~docstring (fun _ -> Py.none)
+      in
+      Gc.full_major ();
+      let other_string = Printf.sprintf "test%d" 43 in
+      let doc = Py.Object.get_attr_string fn "__doc__" in
+      begin
+        match doc with
+          None -> failwith "None!"
+        | Some doc -> assert (Py.String.to_string doc = "test42")
+      end;
+      ignore other_string;
+      Pyml_tests_common.Passed
+    )
+
+let () =
   if not !Sys.interactive then
     Pyml_tests_common.main ()


### PR DESCRIPTION
When wrapping a caml function with a docstring in a python object we currently set `ml_doc` to `String_val(docstring)`. However if the related ocaml string gets collected by the GC later on, the pointer used for `ml_doc` can point to arbitrary data.
This PR creates a copy of the docstring before storing it in `ml_doc`, it also ensures that this copied string gets freed on collection, and adds a dedicated test that fails with the current version but works after this change (this tests uses `Gc.full_major` to trigger some garbage collection and collect the docstring).