### PR TITLE
Catch absence of python binary.

### DIFF
--- a/py.ml
+++ b/py.ml
@@ -532,7 +532,13 @@ let find_interpreter interpreter version minor =
              | None -> which (Printf.sprintf "python%d" version'))
       with
       | Some result -> Some result
-      | None -> which "python"
+      | None ->
+          match which "python" with
+          | Some result -> Some result
+          | None ->
+              match which "python3" with
+              | Some result -> Some result
+              | None -> None
 
 let version_mismatch interpreter found expected =
   Printf.sprintf


### PR DESCRIPTION
In an isolated buildchroot with just python3 installed an executable
named 'python' does not exist. Look also for something named 'python3'.
It is common practice that a plain 'pyhton' refers to python2, so
'python2' is not explicitly checked for.

Signed-off-by: Olaf Hering <olaf@aepfle.de>