### PR TITLE
Add an optional parameter for closure names

### DIFF
--- a/py.ml
+++ b/py.ml
@@ -21,7 +21,7 @@ external load_library: string option -> bool option -> unit = "py_load_library"
 external is_debug_build: unit -> bool = "py_is_debug_build"
 external unsetenv: string -> unit = "py_unsetenv"
 external finalize_library: unit -> unit = "py_finalize_library"
-external pywrap_closure: string -> closure -> pyobject
+external pywrap_closure: string option -> string -> closure -> pyobject
     = "pyml_wrap_closure"
 external pynull: unit -> pyobject = "PyNull_wrapper"
 external pynone: unit -> pyobject = "PyNone_wrapper"
@@ -1942,19 +1942,19 @@ module Callable = struct
         Err.set_error errtype msg;
         null
 
-  let of_function_as_tuple ?(docstring = "Anonymous closure") f =
-    check_not_null (pywrap_closure docstring
+  let of_function_as_tuple ?name ?(docstring = "Anonymous closure") f =
+    check_not_null (pywrap_closure name docstring
       (WithoutKeywords (handle_errors f)))
 
-  let of_function_as_tuple_and_dict ?(docstring = "Anonymous closure") f =
-    check_not_null (pywrap_closure docstring
+  let of_function_as_tuple_and_dict ?name ?(docstring = "Anonymous closure") f =
+    check_not_null (pywrap_closure name docstring
       (WithKeywords (fun args -> handle_errors (f args))))
 
-  let of_function ?docstring f =
-    of_function_as_tuple ?docstring (fun args -> f (Tuple.to_array args))
+  let of_function ?name ?docstring f =
+    of_function_as_tuple ?name ?docstring (fun args -> f (Tuple.to_array args))
 
-  let of_function_with_keywords ?docstring f =
-    of_function_as_tuple_and_dict ?docstring
+  let of_function_with_keywords ?name ?docstring f =
+    of_function_as_tuple_and_dict ?name ?docstring
       (fun args dict -> f (Tuple.to_array args) dict)
 
   let to_function_as_tuple c =

--- a/py.mli
+++ b/py.mli
@@ -414,7 +414,7 @@ module Callable: sig
       Wrapper for
       {{: https://docs.python.org/3/c-api/object.html#c.PyCallable_Check} PyCallable_Check}. *)
 
-  val of_function_as_tuple: ?docstring:string -> (Object.t -> Object.t) ->
+  val of_function_as_tuple: ?name:string -> ?docstring:string -> (Object.t -> Object.t) ->
     Object.t
   (** [of_function_as_tuple f] returns a Python callable object that calls the
       function [f].
@@ -426,17 +426,17 @@ module Callable: sig
       If [f] raises any other exception, this exception bypasses the Python
       interpreter. *)
 
-  val of_function_as_tuple_and_dict: ?docstring:string ->
+  val of_function_as_tuple_and_dict: ?name:string -> ?docstring:string ->
     (Object.t -> Object.t -> Object.t) -> Object.t
   (** [of_function_as_tuple_and_dict f] returns a Python callable object that
       calls the function [f].
       Arguments are passed as a tuple and a dictionary of keywords. *)
 
-  val of_function: ?docstring:string -> (Object.t array -> Object.t) -> Object.t
+  val of_function: ?name:string -> ?docstring:string -> (Object.t array -> Object.t) -> Object.t
   (** Equivalent to {!of_function_as_tuple} but with an array of Python objects
       instead of a tuple for passing arguments. *)
 
-  val of_function_with_keywords: ?docstring:string ->
+  val of_function_with_keywords: ?name:string -> ?docstring:string ->
     (Object.t array -> Object.t -> Object.t) -> Object.t
   (** Equivalent to {!of_function_as_tuple_and_dict} but with an array of
       Python objects instead of a tuple for passing arguments.

--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -482,6 +482,31 @@ let () =
 
 let () =
   Pyml_tests_common.add_test
+    ~title:"function-name"
+    (fun () ->
+      let run make_name expect_name =
+        Gc.full_major ();
+        let fn =
+          let name = make_name () in
+          Py.Callable.of_function ?name (fun _ -> Py.none)
+        in
+        Gc.full_major ();
+        let other_string = Printf.sprintf "test%d" 43 in
+        let name = Py.Object.get_attr_string fn "__name__" in
+        begin
+          match name with
+            None -> failwith "None!"
+          | Some doc -> assert (Py.String.to_string doc = expect_name)
+        end;
+        ignore other_string
+      in
+      run (fun () -> Some (Printf.sprintf "test%d" 42)) "test42";
+      run (fun () -> None) "anonymous_closure";
+      Pyml_tests_common.Passed
+    )
+
+let () =
+  Pyml_tests_common.add_test
     ~title:"is-instance"
     (fun () ->
       let forty_two = Py.Int.of_int 42 in


### PR DESCRIPTION
OCaml closures wrapped in Python use the constant string `anonymous_closure` for their `ml_name`. This PR makes this value easy to tweak to some user-specified value.
The current behavior is preserved and we avoid calling `strdup` in this scenario as it's not needed.

A dedicated test has been included, it's very similar to the docstring test to also check for some potential GC issues.