### PR TITLE
Add an __iter__ method to python iterators.

### DIFF
--- a/py.ml
+++ b/py.ml
@@ -2117,7 +2117,10 @@ module Iter = struct
       match next () with
         None -> raise (Err (Err.StopIteration, ""))
       | Some item -> item in
-    let methods = [next_name, Callable.of_function next'] in
+    let iter_fn = Callable.of_function (function
+      | [||] -> failwith "__iter__ expects at least one argument"
+      | array -> array.(0)) in
+    let methods = [next_name, Callable.of_function next'; "__iter__", iter_fn] in
     Object.call_function_obj_args
       (Class.init ~methods "iterator") [| |]
 

--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -297,6 +297,34 @@ let () =
 
 let () =
   Pyml_tests_common.add_test
+    ~title:"Iterator.create"
+    (fun () ->
+      let iter_of_list l =
+        let current = ref l in
+        fun () ->
+          match !current with
+          | [] -> None
+          | head :: tail ->
+              current := tail;
+              Some (Py.Int.of_int head)
+      in
+      let m = Py.Import.add_module "test" in
+      let iter = Py.Iter.create (iter_of_list [3; 1; 4; 1; 5]) in
+      Py.Module.set m "ocaml_iterator" iter;
+      assert (Py.Run.simple_string "
+from test import ocaml_iterator
+res = 0
+for v in ocaml_iterator: res += v
+assert res == 14
+");
+
+      let iter = Py.Iter.create (iter_of_list [3; 1; 4; 1; 5]) in
+      let list = Py.Iter.to_list_map Py.String.to_string iter in
+      assert (list = ["a"; "b"; "c"]);
+      Pyml_tests_common.Passed)
+
+let () =
+  Pyml_tests_common.add_test
     ~title:"Dict.iter"
     (fun () ->
       let dict = Py.Dict.create () in


### PR DESCRIPTION
Iterators generated by `Py.Iter.create` have a `__next__` method which allows one to iterate over some content.
However using such an iterator in a for loop in python would fail with the iterator not being recognized as `iterable` as it does not implement the `__iter__` method. This PR addes a simple `__iter__` method that returns the object itself, hence it can be used in for loops in python (and in other constructions such as `sum`, ...).
This also adds a test where such an iterator is created and looped over from python.

The python documentation on `__iter__` can be found [here](https://docs.python.org/3/reference/datamodel.html#object.__iter__) and mentions:

> Iterator objects also need to implement this method; they are required to return themselves.
