### PR TITLE
Fix a memory leak in pyml_wrap_closure.

### DIFF
--- a/pyml_stubs.c
+++ b/pyml_stubs.c
@@ -644,6 +644,7 @@ pyml_wrap_closure(value name, value docstring, value closure)
     obj = wrap_capsule(v, "ocaml-closure", camldestr_closure);
     ml_def = (PyMethodDef *) caml_aux(obj);
     PyObject *f = Python_PyCFunction_NewEx(ml_def, obj, NULL);
+    Py_DECREF(obj);
     CAMLreturn(pyml_wrap(f, true));
 }
 


### PR DESCRIPTION
I think there is currently a memory leak in `pyml_wrap_closure` which prevents ocaml closure from being deallocated when a python function created via `Callable.of_function` gets collected on the python side.
Namely `PyCFunction_NewEx(ml, self, module)` increase the reference count on `self` as seen on this [line](https://github.com/python/cpython/blob/3.8/Objects/methodobject.c#L84). This causes the object that gets passed in `pyml_wrap_closure` never to reach an object count of 0 and be de-allocated.
This simple fix decreases the ref count after the call to `PyCFunction_NewEx`.