### PR TITLE
Add support for traceback

### DIFF
--- a/generate.ml
+++ b/generate.ml
@@ -143,8 +143,10 @@ let wrappers =
      arguments = Fun [];
      result = Unit;
      optional = false; };
+   (* PyErr_Restore steals the references.
+      https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Restore *)
    { symbol = "PyErr_Restore";
-     arguments = Fun [PyObject false; PyObject false; PyObject false];
+     arguments = Fun [PyObject true; PyObject true; PyObject true];
      result = Unit;
      optional = false; };
    { symbol = "PyErr_PrintEx";

--- a/generate.ml
+++ b/generate.ml
@@ -143,12 +143,6 @@ let wrappers =
      arguments = Fun [];
      result = Unit;
      optional = false; };
-   (* PyErr_Restore steals the references.
-      https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Restore *)
-   { symbol = "PyErr_Restore";
-     arguments = Fun [PyObject true; PyObject true; PyObject true];
-     result = Unit;
-     optional = false; };
    { symbol = "PyErr_PrintEx";
      arguments = Fun [Int];
      result = Unit;

--- a/numpy_tests.ml
+++ b/numpy_tests.ml
@@ -26,6 +26,37 @@ array[1] = 43.
         end)
 
 let () =
+  Pyml_tests_common.add_test ~title:"of_bigarray2"
+    (fun () ->
+      if Py.Import.try_import_module "numpy" = None then
+        Pyml_tests_common.Disabled "numpy is not available"
+      else
+        begin
+          let array = [| [| 1.; 2.; 3. |]; [| -1.23; Stdcompat.Float.nan; 2.72 |] |] in
+          let array2 =
+            Bigarray.Array2.of_array (Bigarray.float64) (Bigarray.c_layout) array in
+          let bigarray = Bigarray.genarray_of_array2 array2 in
+          let a = Numpy.of_bigarray bigarray in
+          let m = Py.Import.add_module "test" in
+          Py.Module.set m "array" a;
+          assert (Py.Run.simple_string "
+from test import array
+import numpy
+
+assert list(array.shape) == [2, 3]
+numpy.testing.assert_almost_equal(array[0], [1, 2, 3])
+assert(numpy.isnan(array[1, 1]))
+array[0, 0] = 42.
+array[0, 1] = 43.
+array[1, 1] = 1.
+");
+          assert (Bigarray.Array2.get array2 0 0 = 42.);
+          assert (Bigarray.Array2.get array2 0 1 = 43.);
+          assert (Bigarray.Array2.get array2 1 1 = 1.);
+          Pyml_tests_common.Passed
+        end)
+
+let () =
   Pyml_tests_common.add_test ~title:"to_bigarray"
     (fun () ->
       if Py.Import.try_import_module "numpy" = None then
@@ -36,6 +67,7 @@ let () =
           let callback arg =
             let bigarray =
               Numpy.to_bigarray Bigarray.nativeint Bigarray.c_layout arg.(0) in
+            assert (Bigarray.Genarray.dims bigarray = [| 4 |]);
             let array1 = Bigarray.array1_of_genarray bigarray in
             assert (Bigarray.Array1.get array1 0 = 0n);
             assert (Bigarray.Array1.get array1 1 = 1n);
@@ -47,6 +79,46 @@ let () =
 from test import callback
 import numpy
 callback(numpy.array([0,1,2,3]))
+");
+          Pyml_tests_common.Passed
+        end)
+
+let assert_almost_eq ?(eps = 1e-7) f1 f2 =
+  if Float.abs (f1 -. f2) > eps then
+    failwith (Printf.sprintf "%f <> %f" f1 f2)
+
+let () =
+  Pyml_tests_common.add_test ~title:"to_bigarray2"
+    (fun () ->
+      if Py.Import.try_import_module "numpy" = None then
+        Pyml_tests_common.Disabled "numpy is not available"
+      else
+        begin
+          let m = Py.Import.add_module "test" in
+          let callback arg =
+            let bigarray =
+              Numpy.to_bigarray Bigarray.float32 Bigarray.c_layout arg.(0) in
+            assert (Bigarray.Genarray.dims bigarray = [| 2; 4 |]);
+            let array2 = Bigarray.array2_of_genarray bigarray in
+            let assert_almost_eq i j v =
+              assert_almost_eq (Bigarray.Array2.get array2 i j) v in
+            let assert_is_nan i j =
+              let v = Bigarray.Array2.get array2 i j in
+              assert (Stdcompat.Float.is_nan v) in
+            assert_almost_eq 0 0 0.12;
+            assert_almost_eq 0 1 1.23;
+            assert_almost_eq 0 2 2.34;
+            assert_almost_eq 0 3 3.45;
+            assert_almost_eq 1 0 (-1.);
+            assert_is_nan 1 1;
+            assert_almost_eq 1 2 1.;
+            assert_almost_eq 1 3 0.;
+            Py.none in
+          Py.Module.set m "callback" (Py.Callable.of_function callback);
+          assert (Py.Run.simple_string "
+from test import callback
+import numpy
+callback(numpy.array([[0.12,1.23,2.34,3.45],[-1.,numpy.nan,1.,0.]], dtype=numpy.float32))
 ");
           Pyml_tests_common.Passed
         end)

--- a/py.ml
+++ b/py.ml
@@ -34,6 +34,8 @@ external pyobject_callmethodobjargs: pyobject -> pyobject -> pyobject array
   -> pyobject = "PyObject_CallMethodObjArgs_wrapper"
 external pyerr_fetch_internal: unit -> pyobject * pyobject * pyobject
     = "PyErr_Fetch_wrapper"
+external pyerr_restore_internal: pyobject -> pyobject -> pyobject -> unit
+    = "PyErr_Restore_wrapper"
 external pystring_asstringandsize: pyobject -> string option
     = "PyString_AsStringAndSize_wrapper"
 external pyobject_ascharbuffer: pyobject -> string option
@@ -1309,7 +1311,7 @@ module Err = struct
   let print_ex i =
     Pywrappers.pyerr_printex i
 
-  let restore = Pywrappers.pyerr_restore
+  let restore = pyerr_restore_internal
 
   let restore_tuple (ptype, pvalue, ptraceback) =
     restore ptype pvalue ptraceback

--- a/py.ml
+++ b/py.ml
@@ -2059,8 +2059,15 @@ module Callable = struct
         Err.set_error errtype msg;
         null
     | Err_with_traceback (errtype, msg, traceback) ->
-        let traceback = Traceback.create traceback in
-        Err.restore (Err.of_error errtype) (String.of_string msg) traceback;
+        let () =
+          (* Traceback objects can only be created since Python 3.7. *)
+          if !version_major_value <= 2 || (!version_major_value == 3 && !version_minor_value < 7)
+          then
+            Err.set_error errtype msg
+          else
+            let traceback = Traceback.create traceback in
+            Err.restore (Err.of_error errtype) (String.of_string msg) traceback;
+        in
         null
 
   let of_function_as_tuple ?name ?(docstring = "Anonymous closure") f =

--- a/py.ml
+++ b/py.ml
@@ -48,6 +48,8 @@ external pycapsule_isvalid: Pytypes.pyobject -> string -> int
       = "Python27_PyCapsule_IsValid_wrapper"
 external pycapsule_check: Pytypes.pyobject -> int
       = "pyml_capsule_check"
+external pyframe_new : string -> string -> int -> Pytypes.pyobject
+      = "pyml_pyframe_new"
 
 external ucs: unit -> ucs = "py_get_UCS"
 (* Avoid warning 32. *)
@@ -1328,41 +1330,41 @@ module Err = struct
 
   let set_object = Pywrappers.pyerr_setobject
 
+  let of_error = function
+      Exception -> Pywrappers.pyexc_exception ()
+    | StandardError ->
+        if !version_major_value <= 2 then
+          Pywrappers.Python2.pyexc_standarderror ()
+        else
+          Pywrappers.pyexc_exception ()
+    | ArithmeticError -> Pywrappers.pyexc_arithmeticerror ()
+    | LookupError -> Pywrappers.pyexc_lookuperror ()
+    | AssertionError -> Pywrappers.pyexc_assertionerror ()
+    | AttributeError -> Pywrappers.pyexc_attributeerror ()
+    | EOFError -> Pywrappers.pyexc_eoferror ()
+    | EnvironmentError -> Pywrappers.pyexc_environmenterror ()
+    | FloatingPointError -> Pywrappers.pyexc_floatingpointerror ()
+    | IOError -> Pywrappers.pyexc_ioerror ()
+    | ImportError -> Pywrappers.pyexc_importerror ()
+    | IndexError -> Pywrappers.pyexc_indexerror ()
+    | KeyError -> Pywrappers.pyexc_keyerror ()
+    | KeyboardInterrupt -> Pywrappers.pyexc_keyboardinterrupt ()
+    | MemoryError -> Pywrappers.pyexc_memoryerror ()
+    | NameError -> Pywrappers.pyexc_nameerror ()
+    | NotImplementedError -> Pywrappers.pyexc_notimplementederror ()
+    | OSError -> Pywrappers.pyexc_oserror ()
+    | OverflowError -> Pywrappers.pyexc_overflowerror ()
+    | ReferenceError -> Pywrappers.pyexc_referenceerror ()
+    | RuntimeError -> Pywrappers.pyexc_runtimeerror ()
+    | SyntaxError -> Pywrappers.pyexc_syntaxerror ()
+    | SystemExit -> Pywrappers.pyexc_systemerror ()
+    | TypeError -> Pywrappers.pyexc_typeerror ()
+    | ValueError -> Pywrappers.pyexc_valueerror ()
+    | ZeroDivisionError -> Pywrappers.pyexc_zerodivisionerror ()
+    | StopIteration -> Pywrappers.pyexc_stopiteration ()
+
   let set_error error msg =
-    let exc =
-      match error with
-        Exception -> Pywrappers.pyexc_exception ()
-      | StandardError ->
-          if !version_major_value <= 2 then
-            Pywrappers.Python2.pyexc_standarderror ()
-          else
-            Pywrappers.pyexc_exception ()
-      | ArithmeticError -> Pywrappers.pyexc_arithmeticerror ()
-      | LookupError -> Pywrappers.pyexc_lookuperror ()
-      | AssertionError -> Pywrappers.pyexc_assertionerror ()
-      | AttributeError -> Pywrappers.pyexc_attributeerror ()
-      | EOFError -> Pywrappers.pyexc_eoferror ()
-      | EnvironmentError -> Pywrappers.pyexc_environmenterror ()
-      | FloatingPointError -> Pywrappers.pyexc_floatingpointerror ()
-      | IOError -> Pywrappers.pyexc_ioerror ()
-      | ImportError -> Pywrappers.pyexc_importerror ()
-      | IndexError -> Pywrappers.pyexc_indexerror ()
-      | KeyError -> Pywrappers.pyexc_keyerror ()
-      | KeyboardInterrupt -> Pywrappers.pyexc_keyboardinterrupt ()
-      | MemoryError -> Pywrappers.pyexc_memoryerror ()
-      | NameError -> Pywrappers.pyexc_nameerror ()
-      | NotImplementedError -> Pywrappers.pyexc_notimplementederror ()
-      | OSError -> Pywrappers.pyexc_oserror ()
-      | OverflowError -> Pywrappers.pyexc_overflowerror ()
-      | ReferenceError -> Pywrappers.pyexc_referenceerror ()
-      | RuntimeError -> Pywrappers.pyexc_runtimeerror ()
-      | SyntaxError -> Pywrappers.pyexc_syntaxerror ()
-      | SystemExit -> Pywrappers.pyexc_systemerror ()
-      | TypeError -> Pywrappers.pyexc_typeerror ()
-      | ValueError -> Pywrappers.pyexc_valueerror ()
-      | ZeroDivisionError -> Pywrappers.pyexc_zerodivisionerror ()
-      | StopIteration -> Pywrappers.pyexc_stopiteration () in
-    set_object exc (String.of_string msg)
+    set_object (of_error error) (String.of_string msg)
 end
 
 exception Err of Err.t * string
@@ -2017,6 +2019,33 @@ module Set = struct
   let of_list = of_list_map id
 end
 
+module Traceback = struct
+  type frame =
+    { filename : string
+    ; function_name : string
+    ; line_number : int
+    }
+
+  let create_frame { filename; function_name; line_number } =
+    check_not_null (pyframe_new filename function_name line_number)
+
+  type t = frame list
+
+  let create t =
+    let types_module = check_not_null (Pywrappers.pyimport_importmodule "types") in
+    let tb_type = Object.find_attr_string types_module "TracebackType" in
+    List.fold_left
+      (fun acc frame ->
+        let args =
+          Tuple.of_array [| acc; create_frame frame; Int.of_int 0; Int.of_int frame.line_number |]
+        in
+        Eval.call_object tb_type args)
+      none
+      t
+end
+
+exception Err_with_traceback of Err.t * string * Traceback.t
+
 module Callable = struct
   let check v = Pywrappers.pycallable_check v <> 0
 
@@ -2025,8 +2054,13 @@ module Callable = struct
       E (errtype, errvalue) ->
         Err.set_object errtype errvalue;
         null
-    | Err (errtype, msg) ->
+    | Err (errtype, msg)
+    | Err_with_traceback (errtype, msg, []) ->
         Err.set_error errtype msg;
+        null
+    | Err_with_traceback (errtype, msg, traceback) ->
+        let traceback = Traceback.create traceback in
+        Err.restore (Err.of_error errtype) (String.of_string msg) traceback;
         null
 
   let of_function_as_tuple ?name ?(docstring = "Anonymous closure") f =

--- a/py.mli
+++ b/py.mli
@@ -861,8 +861,23 @@ module Err: sig
       instead. *)
 end
 
+module Traceback : sig
+  type frame =
+    { filename : string
+    ; function_name : string
+    ; line_number : int
+    }
+
+  val create_frame : frame -> Object.t
+
+  type t = frame list
+end
+
 exception Err of Err.t * string
 (** Represents an exception to be set with {!Err.set_error} in a callback. *)
+
+exception Err_with_traceback of Err.t * string * Traceback.t
+(** Represents an exception with traceback information to be set with {!Err.restore}. *)
 
 module Eval: sig
   val call_object: Object.t -> Object.t -> Object.t

--- a/pycaml.mli
+++ b/pycaml.mli
@@ -707,7 +707,6 @@ val pyerr_setstring : pyobject * string -> unit
 val pyerr_occurred : unit -> pyobject
 val pyerr_clear : unit -> unit
 val pyerr_fetch : pyobject * pyobject * pyobject -> pyobject * pyobject * pyobject
-val pyerr_restore : pyobject * pyobject * pyobject -> unit
 val pyerr_givenexceptionmatches : pyobject * pyobject -> int
 val pyerr_exceptionmatches : pyobject -> int
 val pyerr_normalizeexception : pyobject * pyobject * pyobject -> pyobject * pyobject * pyobject

--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -192,6 +192,26 @@ except Exception as err:
 
 let () =
   Pyml_tests_common.add_test
+    ~title:"restore with null"
+    (fun () ->
+      try
+        let _ = Py.Run.eval ~start:Py.File "
+raise Exception('Great')
+" in
+        Pyml_tests_common.Failed "uncaught exception"
+      with Py.E (_, value) -> begin
+        assert (Py.Object.to_string value = "Great");
+        match Py.Err.fetched () with
+        | None -> Pyml_tests_common.Failed "unexpected none"
+        | Some (err, _args, _traceback) ->
+            (* Test that using [Py.Err.restore] on null works fine. *)
+            Py.Err.restore err Py.null Py.null;
+            Py.Err.clear ();
+            Pyml_tests_common.Passed
+    end)
+
+let () =
+  Pyml_tests_common.add_test
     ~title:"ocaml other exception"
     (fun () ->
       let m = Py.Import.add_module "test" in

--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -176,13 +176,15 @@ let () =
       Py.Module.set_function m "mywrap" mywrap;
       assert (Py.Run.simple_string "
 from test import mywrap
+import sys
 import traceback
 try:
     mywrap()
     raise Exception('No exception raised')
 except Exception as err:
-    filenames = [f.filename for f in traceback.extract_tb(err.__traceback__)]
-    assert filenames == ['<string>', 'file2.ml', 'file1.ml']
+    if sys.version_info.major == 3 and sys.version_info.minor >= 7:
+        filenames = [f.filename for f in traceback.extract_tb(err.__traceback__)]
+        assert filenames == ['<string>', 'file2.ml', 'file1.ml']
     assert str(err) == \"Great\"
 ");
       Pyml_tests_common.Passed


### PR DESCRIPTION
This PR adds some low level function so that traceback objects can be created from the OCaml side. The main use case is to be able to have the OCaml stacktrace represented in Python exceptions in the same way cython does.
This PR also adds a new exception type for representing Python exceptions with a traceback.

As part of this change, the PyErr_Restore specification has been changed so that it steals objects which I think is in line with the [C api documentation](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Restore). Without this, the new test would segfault.
The wrappers for PyErr_Restore are also written manually rather than generated as null values have to be handled in a specific way. A test has been added to check that this part works fine.