### PR TITLE
Fix wide character conversion bugs

### DIFF
--- a/pyml_stubs.c
+++ b/pyml_stubs.c
@@ -15,7 +15,7 @@
 
 static FILE *(*Python__Py_fopen)(const char *pathname, const char *mode);
 
-static FILE *(*Python__Py_wfopen)(const wchar_t *pathname, const char *mode);
+static FILE *(*Python__Py_wfopen)(const wchar_t *pathname, const wchar_t *mode);
 
 static void *xmalloc(size_t size)
 {
@@ -1226,7 +1226,7 @@ wide_string_of_string(const char *s)
         exit(EXIT_FAILURE);
     }
     wchar_t *ws = xmalloc((n + 1) * sizeof (wchar_t));
-    mbstowcs(ws, s, n);
+    mbstowcs(ws, s, n + 1);
     return ws;
 }
 
@@ -1350,7 +1350,9 @@ open_file(value file, const char *mode)
         }
         else if (Python__Py_wfopen != NULL) {
             wchar_t *wide_filename = wide_string_of_string(filename);
-            result = Python__Py_wfopen(wide_filename, mode);
+            wchar_t *wide_mode = wide_string_of_string(mode);
+            result = Python__Py_wfopen(wide_filename, wide_mode);
+            free(wide_mode);
             free(wide_filename);
         }
         else {


### PR DESCRIPTION
I tried to run the tests on an x86_64 Fedora 35 box.  The "run file with filename" test segfaulted, because the attempt to open the test file for reading failed, returning a NULL, and the NULL was then passed into the python library as a FILE *.  The attempt to open for reading failed because of 2 bugs.  This commit fixes both.

First, the last argument to mbstowcs is not big enough.  It has to cover the null terminator.  Failure to make it big enough led to garbage bytes in the last position, instead of the null terminator.  As the mbstowcs man page says:
```
In order to avoid the case 2 above, the programmer should make sure n is greater than or equal to mbstowcs(NULL,src,0)+1.
```

Second, `_Py_wfopen` wants the mode to be a wide string as well as the filename. I checked old Python versions, and this is the case as far back as Python 3.2, when `_Py_wfopen` was introduced.