### PR TITLE
Remove dependency on stdcompat

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,1 +1,0 @@
-PKG stdcompat

--- a/META
+++ b/META
@@ -1,5 +1,5 @@
 description = "py.ml: OCaml bindings for Python"
-requires = "unix stdcompat"
+requires = "unix"
 version = "20200220"
 archive(byte) = "pyml.cma numpy.cma"
 archive(native) = "pyml.cmxa numpy.cmxa"

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,10 @@ ifneq ($(HAVE_OCAMLFIND),no)
 	OCAMLMKTOP := $(OCAMLFIND) ocamlmktop
 	OCAMLDEP := $(OCAMLFIND) ocamldep
 	OCAMLDOC := $(OCAMLFIND) ocamldoc
-	STDCOMPAT := $(shell $(OCAMLFIND) query stdcompat)
-        OCAMLCFLAGS := -package stdcompat
-        OCAMLLDFLAGS := -linkpkg
-	OCAMLBYTECODELIBS := -package unix,stdcompat
-	OCAMLBYTECODELIBSNUMPY := -package unix,stdcompat,bigarray
-	OCAMLNATIVELIBS := -package unix,stdcompat
-	OCAMLNATIVELIBSNUMPY := -package unix,stdcompat,bigarray
+	OCAMLBYTECODELIBS := -package unix
+	OCAMLBYTECODELIBSNUMPY := -package unix,bigarray
+	OCAMLNATIVELIBS := -package unix
+	OCAMLNATIVELIBSNUMPY := -package unix,bigarray
 else
 	OCAMLC := $(shell \
 		if ocamlc.opt -version >/dev/null 2>&1; then \
@@ -66,17 +63,10 @@ $(error There is no OCaml compiler available in path)
 	OCAMLMKTOP := ocamlmktop
 	OCAMLDEP := ocamldep
 	OCAMLDOC := ocamldoc
-	STDCOMPAT := .
-        OCAMLCFLAGS := -I $(STDCOMPAT)
-        OCAMLLDFLAGS := -I $(STDCOMPAT)
-	OCAMLBYTECODELIBS := unix.cma stdcompat.cma
-	OCAMLBYTECODELIBSNUMPY := unix.cma stdcompat.cma bigarray.cma
-	OCAMLNATIVELIBS := unix.cmxa stdcompat.cmxa
-	OCAMLNATIVELIBSNUMPY := unix.cmxa stdcompat.cmxa bigarray.cmxa
-endif
-
-ifeq ($(wildcard $(STDCOMPAT)/stdcompat.cma),)
-$(error stdcompat module not found: please specify the path with STDCOMPAT=...)
+	OCAMLBYTECODELIBS := unix.cma
+	OCAMLBYTECODELIBSNUMPY := unix.cma bigarray.cma
+	OCAMLNATIVELIBS := unix.cmxa
+	OCAMLNATIVELIBSNUMPY := unix.cmxa bigarray.cmxa
 endif
 
 OCAMLVERSION := $(shell $(OCAMLC) -version)
@@ -171,7 +161,6 @@ endif
 	@echo make OCAMLLDFLAGS=... : set flags to OCaml compiler for linking
 	@echo make OCAMLLIBFLAGS=... :
 	@echo "  set flags to OCaml compiler for building the library"
-	@echo make STDCOMPAT=... : set path to the stdcompat library
 
 .PHONY : all.bytecode
 all.bytecode : pyml.cma numpy.cma
@@ -349,7 +338,7 @@ endif
 #	ocamlmktop raises "Warning 31". See https://github.com/diml/utop/issues/212
 #	$(OCAMLMKTOP) -o $@ -thread -linkpkg -package utop -dontlink compiler-libs $^
 	ocamlfind ocamlc -thread -linkpkg -linkall -predicates create_toploop \
-		-package compiler-libs.toplevel,utop,stdcompat $^ -o $@
+		-package compiler-libs.toplevel,utop $^ -o $@
 
 pyops.ml: pyops.ml.new
 	cp $< $@

--- a/README
+++ b/README
@@ -20,10 +20,6 @@ OPAM: opam install pyml
 The Python library is linked at runtime and the same executable can be
 run in a Python 2 or a Python 3 environment. py.ml does not
 require any Python library at compile time.
-The only compile time dependency is Stdcompat to ensure compatibility
-with all OCaml compiler versions from 3.12:
-https://github.com/thierry-martinez/stdcompat/
-
 
 Bindings are split in three modules:
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ actively maintained.
 The Python library is linked at runtime and the same executable can be
 run in a Python 2 or a Python 3 environment. ``py.ml`` does not
 require any Python library at compile time.
-The only compile time dependency is
-[``Stdcompat``](https://github.com/thierry-martinez/stdcompat) to ensure compatibility
-with all OCaml compiler versions from 3.12.
 
 Bindings are split in three modules:
 

--- a/dune
+++ b/dune
@@ -3,12 +3,12 @@
   (modules numpy py pyops pycaml pyml_arch pytypes pywrappers pyutils)
   (foreign_stubs (language c) (names numpy_stubs pyml_stubs))
   (wrapped false)
-  (libraries bigarray stdcompat))
+  (libraries bigarray unix))
 
 (executables
   (names generate)
   (modules generate)
-  (libraries stdcompat))
+  (libraries unix))
 
 (rule
   (targets pywrappers.ml pyml.h pyml_dlsyms.inc pyml_wrappers.inc)
@@ -30,17 +30,17 @@
 (library
   (name pyml_tests_common)
   (modules pyml_tests_common)
-  (libraries pyml stdcompat))
+  (libraries pyml))
 
 (test
   (name numpy_tests)
   (modules numpy_tests)
-  (libraries pyml pyml_tests_common stdcompat))
+  (libraries pyml pyml_tests_common))
 
 (test
   (name pyml_tests)
   (modules pyml_tests)
-  (libraries pyml pyml_tests_common stdcompat))
+  (libraries pyml pyml_tests_common))
 
 (rule
   (enabled_if (>= %{ocaml_version} 4.06))

--- a/dune-project
+++ b/dune-project
@@ -24,8 +24,6 @@
  (synopsis "OCaml bindings for Python")
  (description "OCaml bindings for Python 2 and Python 3")
  (depends
-  (ocaml (>= 3.12.1))
-  (ocamlfind :build)
-  (stdcompat (>= 18))
+  (ocaml (>= 4.08.0))
   (conf-python-3-dev :with-test))
  (depopts utop))

--- a/generate.ml
+++ b/generate.ml
@@ -1,5 +1,3 @@
-open Stdcompat
-
 type ty =
     PyObject of bool
   | PyCompilerFlags | String | WideString | Int | Int64 | Long | Size | IntPtr

--- a/numpy_tests.ml
+++ b/numpy_tests.ml
@@ -32,7 +32,7 @@ let () =
         Pyml_tests_common.Disabled "numpy is not available"
       else
         begin
-          let array = [| [| 1.; 2.; 3. |]; [| -1.23; Stdcompat.Float.nan; 2.72 |] |] in
+          let array = [| [| 1.; 2.; 3. |]; [| -1.23; Float.nan; 2.72 |] |] in
           let array2 =
             Bigarray.Array2.of_array (Bigarray.float64) (Bigarray.c_layout) array in
           let bigarray = Bigarray.genarray_of_array2 array2 in
@@ -84,7 +84,7 @@ callback(numpy.array([0,1,2,3]))
         end)
 
 let assert_almost_eq ?(eps = 1e-7) f1 f2 =
-  if Stdcompat.Float.abs (f1 -. f2) > eps then
+  if Float.abs (f1 -. f2) > eps then
     failwith (Printf.sprintf "%f <> %f" f1 f2)
 
 let () =
@@ -104,7 +104,7 @@ let () =
               assert_almost_eq (Bigarray.Array2.get array2 i j) v in
             let assert_is_nan i j =
               let v = Bigarray.Array2.get array2 i j in
-              assert (Stdcompat.Float.is_nan v) in
+              assert (Float.is_nan v) in
             assert_almost_eq 0 0 0.12;
             assert_almost_eq 0 1 1.23;
             assert_almost_eq 0 2 2.34;

--- a/py.mli
+++ b/py.mli
@@ -1040,35 +1040,35 @@ module Iter: sig
       tail-recursive and [f] is applied to the elements of [s] in the reverse
       order. *)
 
-  val of_seq: Object.t Stdcompat.Seq.t -> Object.t
+  val of_seq: Object.t Seq.t -> Object.t
   (** [of_seq s] returns an interator that iterates over the values of the
       sequence [s]. *)
 
-  val of_seq_map: ('a -> Object.t) -> 'a Stdcompat.Seq.t -> Object.t
+  val of_seq_map: ('a -> Object.t) -> 'a Seq.t -> Object.t
   (** [of_seq_map f s] returns an interator that iterates over the results of
       [f] applied to the values of the sequence [s].
       [Py.Iter.of_seq_map f s] is equivalent to
       [Py.Iter.of_seq (Seq.map f s)]. *)
 
-  val to_seq: Object.t -> Object.t Stdcompat.Seq.t
+  val to_seq: Object.t -> Object.t Seq.t
   (** [to_seq i] returns the sequence of the values from the iteration [i].
       The Python iteration is consumed while the sequence is browsed.
       Values are memoized, so that the sequence can be browsed many times. *)
 
-  val to_seq_map: (Object.t -> 'a) -> Object.t -> 'a Stdcompat.Seq.t
+  val to_seq_map: (Object.t -> 'a) -> Object.t -> 'a Seq.t
   (** [to_seq_map f i] returns the sequence of the results of [f] applied to the
       values from the iteration [i].
       The Python iteration is consumed while the sequence is browsed.
       Values are memoized, so that the sequence can be browsed many times. *)
 
-  val unsafe_to_seq: Object.t -> Object.t Stdcompat.Seq.t
+  val unsafe_to_seq: Object.t -> Object.t Seq.t
   (** [unsafe_to_seq i] returns the sequence of the values from the iteration
       [i].
       The Python iteration is consumed while the sequence is browsed.
       Warning: values are not memoized, so that the sequence can be browsed
       only once. *)
 
-  val unsafe_to_seq_map: (Object.t -> 'a) -> Object.t -> 'a Stdcompat.Seq.t
+  val unsafe_to_seq_map: (Object.t -> 'a) -> Object.t -> 'a Seq.t
   (** [unsafe_to_seq_map f i] returns the sequence of the results of [f] applied
       to the values from the iteration [i].
       The Python iteration is consumed while the sequence is browsed.
@@ -1195,13 +1195,13 @@ module List: sig
   val of_sequence: Object.t -> Object.t
   (** Equivalent to {!Sequence.list}. *)
 
-  val of_seq: Object.t Stdcompat.Seq.t -> Object.t
+  val of_seq: Object.t Seq.t -> Object.t
   (** [of_seq s] returns the Python list with the same elements as [s]. *)
 
-  val to_seq: Object.t -> Object.t Stdcompat.Seq.t
+  val to_seq: Object.t -> Object.t Seq.t
   (** Equivalent to {!Sequence.to_seq}. *)
 
-  val to_seqi: Object.t -> (int * Object.t) Stdcompat.Seq.t
+  val to_seqi: Object.t -> (int * Object.t) Seq.t
   (** Equivalent to {!Sequence.to_seqi}. *)
 
   val singleton: Object.t -> Object.t
@@ -1702,11 +1702,11 @@ module Sequence: sig
       tail-recursive and [f] is applied to the elements of [s] in the reverse
       order. *)
 
-  val to_seq: Object.t -> Object.t Stdcompat.Seq.t
+  val to_seq: Object.t -> Object.t Seq.t
   (** [to_seq s] returns the OCaml sequence of the values from the Python
       sequence [s]. *)
 
-  val to_seqi: Object.t -> (int * Object.t) Stdcompat.Seq.t
+  val to_seqi: Object.t -> (int * Object.t) Seq.t
   (** [to_seqi s] returns the OCaml indexed sequence of the values from the
       Python sequence [s]. *)
 
@@ -1793,7 +1793,7 @@ module String: sig
   (** [of_string s] returns the Python string with the value [s].
       [s] should be a valid UTF-8 string. *)
 
-  val of_bytes: Stdcompat.bytes -> Object.t
+  val of_bytes: bytes -> Object.t
   (** Same as [of_string] but with an argument of type [bytes]. *)
 
   val to_string: Object.t -> string
@@ -1801,7 +1801,7 @@ module String: sig
       A failure ([Failure _]) is raised if [o] is neither a
       [String]/[Bytes] value nor a [Unicode] value. *)
 
-  val to_bytes: Object.t -> Stdcompat.bytes
+  val to_bytes: Object.t -> bytes
   (** Same as [to_string] but with an a result of type [bytes]. *)
 
   val of_unicode: ?size:int -> int array -> Object.t
@@ -1820,13 +1820,13 @@ module Bytes: sig
   (** [of_string s] returns the Python byte sequence with the contents of
       [s]. *)
 
-  val of_bytes: Stdcompat.bytes -> Object.t
+  val of_bytes: bytes -> Object.t
   (** Same as [of_string] but with an argument of type [bytes]. *)
 
   val to_string: Object.t -> string
   (** [to_string o] returns the string contained in the Python value [o]. *)
 
-  val to_bytes: Object.t -> Stdcompat.bytes
+  val to_bytes: Object.t -> bytes
   (** Same as [to_string] but with an a result of type [bytes]. *)
 
   val length: Object.t -> int
@@ -1903,13 +1903,13 @@ module Tuple: sig
   val to_list_map: (Object.t -> 'a) -> Object.t -> 'a list
   (** Equivalent to {!Sequence.to_list_map}. *)
 
-  val of_seq: Object.t Stdcompat.Seq.t -> Object.t
+  val of_seq: Object.t Seq.t -> Object.t
   (** [of_seq s] returns the Python tuple with the values of the sequence s. *)
 
-  val to_seq: Object.t -> Object.t Stdcompat.Seq.t
+  val to_seq: Object.t -> Object.t Seq.t
   (** Equivalent to {!Sequence.to_seq}. *)
 
-  val to_seqi: Object.t -> (int * Object.t) Stdcompat.Seq.t
+  val to_seqi: Object.t -> (int * Object.t) Seq.t
   (** Equivalent to {!Sequence.to_seqi}. *)
 
   val fold_left: ('a -> Object.t -> 'a) -> 'a -> Object.t -> 'a
@@ -2112,7 +2112,7 @@ module Array: sig
   val pyarray_type: unit -> Object.t
   (** Returns the type of Numpy arrays. *)
 
-  val numpy: Stdcompat.floatarray -> Object.t
+  val numpy: floatarray -> Object.t
   (** [numpy a] returns a Numpy array that shares the same contents than
       the OCaml array [a].
       The array is passed in place (without copy) which relies on the
@@ -2122,7 +2122,7 @@ module Array: sig
       Note that the {!Numpy} module provides a more general interface
       between Numpy arrays and OCaml bigarrays. *)
 
-  val numpy_get_array: Object.t -> Stdcompat.floatarray
+  val numpy_get_array: Object.t -> floatarray
   (** [numpy_get_array a] returns the OCaml array from which the Numpy
       array [a] has been converted from. Note that this function fails
       if [a] has not been obtained by calling the {!numpy} function

--- a/pycaml.ml
+++ b/pycaml.ml
@@ -466,7 +466,7 @@ let unpythonizing_function ?name ?(catch_weird_exceptions = true) ?extra_guards
 
 let py_profiling_active = ref false
 
-let py_profile_hash = Stdcompat.Lazy.from_fun (fun () -> Hashtbl.create 100)
+let py_profile_hash = Lazy.from_fun (fun () -> Hashtbl.create 100)
 
 let py_activate_profiling () =
   let old_value = !py_profiling_active in

--- a/pyml.opam
+++ b/pyml.opam
@@ -10,9 +10,7 @@ doc: "http://github.com/thierry-martinez/pyml"
 bug-reports: "http://github.com/thierry-martinez/pyml/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "3.12.1"}
-  "ocamlfind" {build}
-  "stdcompat" {>= "18"}
+  "ocaml" {>= "4.08.0"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]
@@ -32,4 +30,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
-version: "20220325"

--- a/pyml_stubs.c
+++ b/pyml_stubs.c
@@ -11,7 +11,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <stdcompat.h>
 #include <assert.h>
 #include "pyml_stubs.h"
 

--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -527,9 +527,9 @@ let () =
         Pyml_tests_common.Disabled "numpy is not available"
       else
         begin
-          let array = Stdcompat.Array.Floatarray.create 2 in
-          Stdcompat.Array.Floatarray.set array 0 1.;
-          Stdcompat.Array.Floatarray.set array 1 2.;
+          let array = Array.Floatarray.create 2 in
+          Array.Floatarray.set array 0 1.;
+          Array.Floatarray.set array 1 2.;
           let a = Py.Array.numpy array in
           let m = Py.Import.add_module "test" in
           Py.Module.set m "array" a;
@@ -541,8 +541,8 @@ assert array[1] == 2.
 array[0] = 42.
 array[1] = 43.
 ");
-          assert (Stdcompat.Array.Floatarray.get array 0 = 42.);
-          assert (Stdcompat.Array.Floatarray.get array 1 = 43.);
+          assert (Array.Floatarray.get array 0 = 42.);
+          assert (Array.Floatarray.get array 1 = 43.);
           Pyml_tests_common.Passed
         end)
 
@@ -553,7 +553,7 @@ let () =
         Pyml_tests_common.Disabled "numpy is not available"
       else
         begin
-          let array = Stdcompat.Float.Array.init 0x10000 float_of_int in
+          let array = Float.Array.init 0x10000 float_of_int in
           let numpy_array = Py.Array.numpy array in
           let add =
             Py.Module.get_function (Py.Import.import_module "numpy") "add" in
@@ -562,16 +562,16 @@ let () =
               numpy_array
             else
               let array =
-                Stdcompat.Float.Array.map_from_array Stdcompat.Fun.id
+                Float.Array.map_from_array Fun.id
                   (Py.Sequence.to_array_map Py.Float.to_float
                      (add [| numpy_array; numpy_array |])) in
               crunch (Py.Array.numpy array) (pred n) in
           ignore (crunch (Py.Array.numpy array) 0x100);
-          assert (Stdcompat.Float.Array.length array = 0x10000);
+          assert (Float.Array.length array = 0x10000);
           for i = 0 to 0x10000 - 1 do
-            assert (Stdcompat.Float.Array.get array i = float_of_int i)
+            assert (Float.Array.get array i = float_of_int i)
           done;
-          Stdcompat.Float.Array.set array 1 42.;
+          Float.Array.set array 1 42.;
           assert (Py.Float.to_float (Py.Sequence.get numpy_array 1) = 42.);
           Pyml_tests_common.Passed
         end)


### PR DESCRIPTION
Hi!

I'm currently looking into porting some community projects to dune to make them compatible with [`opam-monorepo`](https://github.com/ocamllabs/opam-monorepo) (I'm porting Tezos dependencies to allow Tezos to be built with opam-monorepo).

`pyml` is one of those dependencies: it uses dune, but its reliance on `stdcompat` makes it incompatible with `opam-monorepo` as `stdcompat` can't be built with dune.

I'm opening this PR with a proposed solution, but this is mostly to open the discussion.

The PR removes the dependency on `stdcompat`. This makes `pyml` dependency-free (and thus compatible with opam-monorepo), but to avoid vendoring all of `stdcompat`, we also bump the minimal supported OCaml version to 4.08.0. The reason for choosing 4.08.0 was:

- Pyml uses dune, which needs 4.08.0 to be compiled. So at the moment, the project has to install 4.08.0 as `ocaml-secondary-compiler` anyways if the users want to build on OCaml<4.08.0.
- Most stdlib functions used in `pyml` are available in OCaml 4.08.0.
- OCaml 4.08.0 was released 3 years ago, so hopefully it is a good candidate for a minimal support version for newer versions of `pyml`.

If bumping the supported OCaml version isn't an option, I'd be happy to work on other solutions that you'd be open to consider for merge, e.g.:

- Porting `stdcompat` itself to dune
- Vendoring `stdcompat` in `pyml`
- Not upstreaming our dune port and keep it in [`opam-overlays`](https://github.com/dune-universe/opam-overlays)

Thank you!