### PR TITLE
Fix #85: segmentation fault by forgetting objects on library unloading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 [*] marks changes that break compatibility with previous versions.
 
+# Development version
+
+- Fix segmentation fault by forgetting objects on library unloading
+  (observed on Fedora Rawhide with address randomization)
+  (reported by Jerry James,
+  https://github.com/thierry-martinez/pyml/issues/85)
+
 # 2022-09-05
 
 - Support for OCaml 5.0

--- a/py.ml
+++ b/py.ml
@@ -783,11 +783,16 @@ let is_none v =
 
 exception E of pyobject * pyobject
 
-let fetched_exception = ref None
+let create_ref_to_python_object () =
+  let result = ref None in
+  on_finalize (fun () -> result := None);
+  result
 
-let ocaml_exception_class = ref None
+let fetched_exception = create_ref_to_python_object ()
 
-let ocaml_exception_capsule = ref None
+let ocaml_exception_class = create_ref_to_python_object ()
+
+let ocaml_exception_capsule = create_ref_to_python_object ()
 
 let python_exception () =
   let ptype, pvalue, ptraceback = pyerr_fetch_internal () in


### PR DESCRIPTION
Reported by Jerry James, https://github.com/thierry-martinez/pyml/issues/85