### PR TITLE
dune: Fix top-level installation

### DIFF
--- a/dune
+++ b/dune
@@ -11,6 +11,23 @@
   (libraries stdcompat))
 
 (rule
+  (target pymltop_libdir.ml)
+  (action (with-stdout-to %{target}
+    (run echo "let libdir=\"%{project_root}/lib/pyml/\""))))
+
+(executable
+  (name pytop)
+  (public_name pymltop)
+  (modules pytop pymltop_libdir)
+  (libraries compiler-libs))
+
+(executable
+  (name pyutop)
+  (public_name pymlutop)
+  (modules pyutop)
+  (libraries utop))
+
+(rule
   (targets pywrappers.ml pyml.h pyml_dlsyms.inc pyml_wrappers.inc)
   (deps (:gen generate.exe))
   (action (run %{gen})))


### PR DESCRIPTION
Currently does not build:

```
building
    ocamlopt pytop.exe (exit 2)
(cd _build/default && /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/bin/ocamlopt.opt -w -40 -g -o pytop.exe .pytop.eobjs/native/dune__exe.cmx .pytop.eobjs/native/dune__exe__Pymltop_libdir.cmx .pytop.eobjs/native/dune__exe__Pytop.cmx)
File "_none_", line 1:
Error: No implementations provided for the following modules:
         Toploop referenced from .pytop.eobjs/native/dune__exe__Pytop.cmx
```

and

```
building
    ocamlopt .pyutop.eobjs/native/dune__exe__Pyutop.{cmx,o}
File "_none_", line 1:
Warning 58 [no-cmx-file]: no cmx file was found in path for module UTop_main, and its interface was not compiled with -opaque
    ocamlopt pyutop.exe (exit 2)
(cd _build/default && /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/bin/ocamlopt.opt -w -40 -g -o pyutop.exe /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml/compiler-libs/ocamlcommon.cmxa /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml/compiler-libs/ocamlbytecomp.cmxa /nix/store/bgvrgmks30gxafy3sh60ng6dykicna2b-ocaml-findlib-1.9.3/lib/ocaml/4.14.0/site-lib/findlib/findlib.cmxa /nix/store/bgvrgmks30gxafy3sh60ng6dykicna2b-ocaml-findlib-1.9.3/lib/ocaml/4.14.0/site-lib/findlib/findlib_top.cmxa /nix/store/jrphls518xviz7zwj5c3qc68d3mpva3a-ocaml4.14.0-result-1.5/lib/ocaml/4.14.0/site-lib/result/result.cmxa /nix/store/dr52y52442zh2hzaxbiswv5jsxak95r7-ocaml4.14.0-lwt-5.5.0/lib/ocaml/4.14.0/site-lib/lwt/lwt.cmxa /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml/unix.cmxa -I /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml/bigarray.cmxa -I /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml /nix/store/sbz98lbzxlqlkiww9ppzw780sgbg2c03-ocaml4.14.0-mmap-1.1.0/lib/ocaml/4.14.0/site-lib/mmap/mmap.cmxa /nix/store/4aj6hrgxiigj84zyqz6z3vjdrzz3j94b-ocaml4.14.0-ocplib-endian-1.2/lib/ocaml/4.14.0/site-lib/ocplib-endian/ocplib_endian.cmxa /nix/store/4aj6hrgxiigj84zyqz6z3vjdrzz3j94b-ocaml4.14.0-ocplib-endian-1.2/lib/ocaml/4.14.0/site-lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml/threads/threads.cmxa -I /nix/store/xnyj7c27kdyf6pxfdqv04l2i8fdpmp6p-ocaml-4.14.0/lib/ocaml /nix/store/dr52y52442zh2hzaxbiswv5jsxak95r7-ocaml4.14.0-lwt-5.5.0/lib/ocaml/4.14.0/site-lib/lwt/unix/lwt_unix.cmxa -I /nix/store/dr52y52442zh2hzaxbiswv5jsxak95r7-ocaml4.14.0-lwt-5.5.0/lib/ocaml/4.14.0/site-lib/lwt/unix /nix/store/xm570wj1aj7vwkgzzygc8ii8a8wk7080-ocaml-react-1.2.1/lib/ocaml/4.14.0/site-lib/react/react.cmxa /nix/store/cfr9kw5qyrabrg46faf7nxcp2wl1v1l1-ocaml4.14.0-lwt_react-1.1.5/lib/ocaml/4.14.0/site-lib/lwt_react/lwt_react.cmxa /nix/store/b89j619h9vq8d1iljpr5bvc5v03kp2il-ocaml4.14.0-camomile-1.0.2/lib/ocaml/4.14.0/site-lib/camomile/default_config/camomileDefaultConfig.cmxa /nix/store/b89j619h9vq8d1iljpr5bvc5v03kp2il-ocaml4.14.0-camomile-1.0.2/lib/ocaml/4.14.0/site-lib/camomile/library/camomileLibrary.cmxa /nix/store/b89j619h9vq8d1iljpr5bvc5v03kp2il-ocaml4.14.0-camomile-1.0.2/lib/ocaml/4.14.0/site-lib/camomile/lib_default/camomileLibraryDefault.cmxa /nix/store/b89j619h9vq8d1iljpr5bvc5v03kp2il-ocaml4.14.0-camomile-1.0.2/lib/ocaml/4.14.0/site-lib/camomile/dyn/camomileLibraryDyn.cmxa /nix/store/b89j619h9vq8d1iljpr5bvc5v03kp2il-ocaml4.14.0-camomile-1.0.2/lib/ocaml/4.14.0/site-lib/camomile/camomile_yuge.cmxa /nix/store/h8wp1yi799v7h70khsf9xy7a5xxckw4q-ocaml4.14.0-charInfo_width-1.1.0/lib/ocaml/4.14.0/site-lib/charInfo_width/charInfo_width.cmxa /nix/store/sy7hzwq1k6a68rgwx4yvchg5vli5nwxl-ocaml4.14.0-zed-3.1.0/lib/ocaml/4.14.0/site-lib/zed/zed.cmxa /nix/store/d51ddknw86c07fp55s1i70hxsizl8j07-ocaml4.14.0-lwt_log-1.1.2/lib/ocaml/4.14.0/site-lib/lwt_log/core/lwt_log_core.cmxa /nix/store/d51ddknw86c07fp55s1i70hxsizl8j07-ocaml4.14.0-lwt_log-1.1.2/lib/ocaml/4.14.0/site-lib/lwt_log/lwt_log.cmxa /nix/store/kp0jbcfjiq45irfyv89l8b07ii7qg73y-ocaml4.14.0-trie-1.0.0/lib/ocaml/4.14.0/site-lib/trie/trie.cmxa /nix/store/9f8f5sfz10lwac5k3adwjg4hlc602gk2-ocaml4.14.0-mew-0.1.0/lib/ocaml/4.14.0/site-lib/mew/mew.cmxa /nix/store/h55ym2m7aapfxw9afs4d7k682vq6labk-ocaml4.14.0-mew_vi-0.5.0/lib/ocaml/4.14.0/site-lib/mew_vi/mew_vi.cmxa /nix/store/mpp5armq3ngh7s5xwd13g16rgqx1zcs5-ocaml4.14.0-lambda-term-3.2.0/lib/ocaml/4.14.0/site-lib/lambda-term/lambda_term.cmxa -I /nix/store/mpp5armq3ngh7s5xwd13g16rgqx1zcs5-ocaml4.14.0-lambda-term-3.2.0/lib/ocaml/4.14.0/site-lib/lambda-term .pyutop.eobjs/native/dune__exe__Pyutop.cmx)
File "_none_", line 1:
Error: No implementations provided for the following modules:
         UTop_main referenced from .pyutop.eobjs/native/dune__exe__Pyutop.cmx
```

and I am not sure how to insert the libdir properly.
