### PR TITLE
fix: use tool instead of ldd on Mac

### DIFF
--- a/py.ml
+++ b/py.ml
@@ -207,7 +207,10 @@ let uninit_pythonpath () =
       end
 
 let ldd executable =
-  let command = Printf.sprintf "ldd %s" executable in
+  let command =
+    match Pyml_arch.os with
+    | Pyml_arch.Mac -> Printf.sprintf "otool -L %s" executable
+    | _ -> Printf.sprintf "ldd %s" executable in
   match run_command_opt command false with
     None -> []
   | Some lines ->


### PR DESCRIPTION
The heuristic to find lib python use ldd and the equivalent tool on Mac is tool with -L flags. Without this some tests failed because it didn't find the lib.