### PR TITLE
Fix #93: `get_attr_string` returns `None` when attribute is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@
   (reported by Jerry James,
   https://github.com/thierry-martinez/pyml/issues/85)
 
+- #93, #94: Fix `Py.Object.get_attr_string`: this function now returns
+  `None` when attribute is missing (the former version raised an
+  exception, despite the `option` return type and contrary to what was
+  documented) (reported by Lindsay Errington, @dlindsaye,
+  https://github.com/thierry-martinez/pyml/issues/93)
+
+- #94: Better search heuristics for `python` library
+
 # 2022-09-05
 
 - Support for OCaml 5.0

--- a/pyml_tests.ml
+++ b/pyml_tests.ml
@@ -710,5 +710,13 @@ let () =
       Pyml_tests_common.Passed)
 
 let () =
+  Pyml_tests_common.add_test
+    ~title:"get_attr_string"
+    (fun () ->
+       let bool_ty = Py.Object.get_type Py.Bool.t in
+       assert (Py.Object.get_attr_string bool_ty "dtype" = None);
+       Pyml_tests_common.Passed)
+
+let () =
   if not !Sys.interactive then
     Pyml_tests_common.main ()


### PR DESCRIPTION
`get_attr_string` returns `None` and no longer fails when attribute is missing.