### PR TITLE
also check for __unix__. Fixes build on NetBSD

### DIFF
--- a/pyml_arch.ml.c
+++ b/pyml_arch.ml.c
@@ -5,6 +5,8 @@
   #define WIN_HANDLE_FD
 #elif unix
   #define PLATFORM_NAME Unix
+#elif __unix__
+  #define PLATFORM_NAME Unix
 #else
   #error "Unknown platform"
 #endif


### PR DESCRIPTION
(This might not be the cleanest way to do it, but on my machine unix is not defined but __unix__ is.)