### PR TITLE
`unable_to_parse` from `libpython_from_pkg_config` should be caught in `find_library_path`

### DIFF
--- a/py.ml
+++ b/py.ml
@@ -522,7 +522,7 @@ let find_library_path version_major version_minor python_full_path =
         Option.bind version_minor (fun version_minor ->
           libpython_from_pythonpath version_major version_minor)));
   ] in
-  List.concat (List.map (fun f -> Option.value ~default:[] (f ())) heuristics)
+  List.concat (List.map (fun f -> Option.value ~default:[] (try f () with _ -> None)) heuristics)
 
 let python_version_from_interpreter interpreter =
   let version_line =


### PR DESCRIPTION
I had an issue of not being able to initialize pyml with a trace:
```
Uncaught exception:

  (Failure
   "Py.find_library_path: unable to parse the output of pkg-config '-L/opt/homebrew/opt/python@3.12/Frameworks/Python.framework/Versions/3.12/lib'")

Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Py.libpython_from_pkg_config in file "py.ml", line 410, characters 18-36
Called from Py.find_library_path.(fun) in file "py.ml", line 525, characters 59-65
Called from Stdlib__List.map in file "list.ml", line 86, characters 15-19
Called from Stdlib__List.map in file "list.ml", line 88, characters 14-21
Called from Py.find_library_path in file "py.ml", line 525, characters 14-78
Called from Py.find_library in file "py.ml", line 548, characters 6-68
Called from Py.initialize_library in file "py.ml", line 594, characters 2-87
Called from Py.initialize.do_initialize in file "py.ml", line 760, characters 10-109
Re-raised at Py.initialize.do_initialize in file "py.ml", line 765, characters 10-17
Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
Called from Py.initialize in file "py.ml", line 769, characters 4-29
```

Not really sure why that cannot be parsed, but I believe exns raised by `unable_to_parse` in `libpython_from_pkg_config` should be caught in `find_library_path`, as it is just one of multiple heuristics failing. Moreover, the mapping function already expects something optional with `Option.value ~default:[]`.